### PR TITLE
fix: use MappingView instead of Iterable for dict views serialization

### DIFF
--- a/src/envoxy/utils/encoders.py
+++ b/src/envoxy/utils/encoders.py
@@ -1,6 +1,7 @@
 import datetime
 import decimal
 import json
+from collections.abc import MappingView
 
 import orjson
 
@@ -41,6 +42,10 @@ def envoxy_json_encode_default(obj):
 
     if isinstance(obj, (datetime.datetime, datetime.date)):
         return obj.isoformat()
+
+    # Handle dict views (dict_keys, dict_values, dict_items) that orjson can't serialize natively.
+    if isinstance(obj, MappingView):
+        return list(obj)
 
     raise TypeError
 


### PR DESCRIPTION
Replace the overly broad Iterable check with MappingView from collections.abc, which precisely covers dict_keys, dict_values, and dict_items without silently catching sets, generators, or other custom iterables that should raise TypeError.