### PR TITLE
Fix/postgres datetime utc

### DIFF
--- a/src/envoxy/postgresql/client.py
+++ b/src/envoxy/postgresql/client.py
@@ -4,7 +4,7 @@ import uuid
 import re
 from time import sleep
 from threading import BoundedSemaphore as _BoundedSemaphore, Lock, local
-from datetime import datetime, timezone
+from datetime import datetime, date, timezone
 from contextlib import contextmanager
 
 from psycopg2.pool import ThreadedConnectionPool
@@ -22,6 +22,23 @@ from ..constants import (
     DEFAULT_OFFSET_LIMIT,
     DEFAULT_CHUNK_SIZE,
 )
+
+
+def _normalize_row(row: dict) -> dict:
+    """Convert datetime values in a psycopg2 result row to the platform UTC format.
+
+    - datetime (TIMESTAMP / TIMESTAMPTZ): converted to "YYYY-MM-DDTHH:MM:SS.fff+0000"
+    - date (DATE): left as isoformat string "YYYY-MM-DD" — no time component to normalize
+    """
+    for key, value in row.items():
+        if isinstance(value, datetime):
+            # psycopg2 returns naive datetimes for TIMESTAMP (assume UTC)
+            # and aware datetimes for TIMESTAMPTZ (convert to UTC)
+            dt_utc = value if value.tzinfo is None else value.astimezone(timezone.utc)
+            row[key] = dt_utc.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "+0000"
+        elif isinstance(value, date):
+            row[key] = value.isoformat()
+    return row
 
 
 class SemaphoreThreadedConnectionPool(ThreadedConnectionPool):
@@ -441,7 +458,9 @@ class Client:
                     _rowcount = _cursor.rowcount
                     _rows = _cursor.fetchall()
 
-                    _data.extend(list(map(dict, _rows)))
+                    _data.extend(
+                        [_normalize_row(dict(row)) for row in _rows]
+                    )
 
                     _offset_limit += _chunk_size
                     _local_params.update({"offset_limit": _offset_limit})

--- a/src/envoxy/utils/encoders.py
+++ b/src/envoxy/utils/encoders.py
@@ -1,6 +1,7 @@
 import datetime
 import decimal
 import json
+from collections.abc import MappingView
 
 import orjson
 
@@ -39,8 +40,17 @@ def envoxy_json_encode_default(obj):
     if isinstance(obj, decimal.Decimal):
         return float(obj)
 
-    if isinstance(obj, (datetime.datetime, datetime.date)):
+    # datetime before date — datetime is a subclass of date
+    if isinstance(obj, datetime.datetime):
+        dt_utc = obj if obj.tzinfo is None else obj.astimezone(datetime.timezone.utc)
+        return dt_utc.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "+0000"
+
+    if isinstance(obj, datetime.date):
         return obj.isoformat()
+
+    # Handle dict views (dict_keys, dict_values, dict_items) that orjson can't serialize natively.
+    if isinstance(obj, MappingView):
+        return list(obj)
 
     raise TypeError
 
@@ -78,7 +88,12 @@ class EnvoxyJsonEncoder(json.JSONEncoder):
         if isinstance(o, decimal.Decimal):
             return float(o)
 
-        if isinstance(o, (datetime.date, datetime.datetime)):
+        # datetime before date — datetime is a subclass of date
+        if isinstance(o, datetime.datetime):
+            dt_utc = o if o.tzinfo is None else o.astimezone(datetime.timezone.utc)
+            return dt_utc.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "+0000"
+
+        if isinstance(o, datetime.date):
             return o.isoformat()
 
         return super(EnvoxyJsonEncoder, self).default(o)

--- a/src/envoxy/utils/encoders.py
+++ b/src/envoxy/utils/encoders.py
@@ -20,30 +20,16 @@ def _fmt_datetime(dt):
     return dt_utc.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "+0000"
 
 
-def _normalize_obj(obj):
-    """
-    Single-pass recursive pre-processor for orjson serialization.
-
-    Handles in one traversal:
-    - datetime → platform UTC string ('YYYY-MM-DDTHH:MM:SS.fff+0000')
-      orjson serializes datetime natively (bypassing default()), producing
-      inconsistent formats. Converting to string first ensures correct output.
-    - int outside 64-bit range → str
-      orjson only supports [−2^63, 2^64−1]; large integers raise TypeError.
-
-    date objects pass through untouched — orjson emits them as 'YYYY-MM-DD'.
-    All other scalars (str, float, bool, None, Decimal, etc.) pass through.
-    """
-    if isinstance(obj, datetime.datetime):
-        return _fmt_datetime(obj)
-    elif isinstance(obj, int):
+def _convert_large_integers(obj):
+    """Recursively convert integers outside orjson's 64-bit range to strings."""
+    if isinstance(obj, int):
         if obj > UINT64_MAX or obj < INT64_MIN:
             return str(obj)
         return obj
     elif isinstance(obj, dict):
-        return {key: _normalize_obj(value) for key, value in obj.items()}
+        return {key: _convert_large_integers(value) for key, value in obj.items()}
     elif isinstance(obj, (list, tuple)):
-        return type(obj)(_normalize_obj(item) for item in obj)
+        return type(obj)(_convert_large_integers(item) for item in obj)
     else:
         return obj
 
@@ -52,10 +38,12 @@ def envoxy_json_encode_default(obj):
     if isinstance(obj, decimal.Decimal):
         return float(obj)
 
-    # datetime before date — datetime is a subclass of date
+    # datetime before date — datetime is a subclass of date.
+    # Called by orjson because we use OPT_PASSTHROUGH_DATETIME, which disables
+    # orjson's native datetime serialisation and routes all datetime/date objects
+    # here so we can emit the platform UTC format.
     if isinstance(obj, datetime.datetime):
-        dt_utc = obj if obj.tzinfo is None else obj.astimezone(datetime.timezone.utc)
-        return dt_utc.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "+0000"
+        return _fmt_datetime(obj)
 
     if isinstance(obj, datetime.date):
         return obj.isoformat()
@@ -67,15 +55,28 @@ def envoxy_json_encode_default(obj):
     raise TypeError
 
 
+# OPT_PASSTHROUGH_DATETIME disables orjson's native datetime serialisation,
+# routing datetime/date objects through envoxy_json_encode_default instead.
+# This lets us emit the platform UTC format without a pre-processing tree walk.
+_ORJSON_OPTS = orjson.OPT_PASSTHROUGH_DATETIME
+
+
 def envoxy_json_dumps(obj):
     """
     Serialize object to JSON bytes using orjson.
 
-    Pre-processes the object tree with _normalize_obj (single pass) to handle:
-    - datetime → platform UTC string (orjson bypasses default() for datetime)
-    - int outside 64-bit range → str (orjson raises TypeError for these)
+    datetime/date objects are handled by envoxy_json_encode_default via
+    OPT_PASSTHROUGH_DATETIME — no pre-processing tree walk needed.
+
+    Large integers (outside orjson's 64-bit range) are handled on the slow
+    path: first attempt raises TypeError, then we pre-process and retry.
     """
-    return orjson.dumps(_normalize_obj(obj), default=envoxy_json_encode_default)
+    try:
+        return orjson.dumps(obj, default=envoxy_json_encode_default, option=_ORJSON_OPTS)
+    except TypeError as e:
+        if "Integer exceeds 64-bit range" in str(e):
+            return orjson.dumps(_convert_large_integers(obj), default=envoxy_json_encode_default, option=_ORJSON_OPTS)
+        raise
 
 
 def envoxy_json_loads(obj):

--- a/src/envoxy/utils/encoders.py
+++ b/src/envoxy/utils/encoders.py
@@ -14,51 +14,36 @@ UINT64_MAX = 18446744073709551615  # 2^64 - 1 (max positive)
 INT64_MIN = -9223372036854775808  # -2^63 (min negative)
 
 
-def _convert_large_integers(obj):
-    """
-    Recursively convert integers exceeding 64-bit range to strings.
-
-    orjson supports: positive integers [0, 2^64-1], negative integers [-2^63, 0].
-    This function pre-processes data structures to convert any integers outside
-    this range to strings before serialization.
-
-    Optimized to minimize overhead for common cases without large integers.
-    """
-    if isinstance(obj, int):
-        if obj > UINT64_MAX or obj < INT64_MIN:
-            return str(obj)
-        return obj
-    elif isinstance(obj, dict):
-        return {key: _convert_large_integers(value) for key, value in obj.items()}
-    elif isinstance(obj, (list, tuple)):
-        return type(obj)(_convert_large_integers(item) for item in obj)
-    else:
-        return obj
-
-
 def _fmt_datetime(dt):
     """Format a datetime to platform UTC format: YYYY-MM-DDTHH:MM:SS.fff+0000."""
     dt_utc = dt if dt.tzinfo is None else dt.astimezone(datetime.timezone.utc)
     return dt_utc.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "+0000"
 
 
-def _convert_datetimes(obj):
+def _normalize_obj(obj):
     """
-    Recursively convert datetime objects to the platform UTC string format.
+    Single-pass recursive pre-processor for orjson serialization.
 
-    orjson serializes datetime natively (bypassing the default function),
-    producing inconsistent formats (+00:00, 6 decimal places, non-UTC offsets).
-    Pre-processing ensures all datetime values are normalized before orjson
-    sees them.
+    Handles in one traversal:
+    - datetime → platform UTC string ('YYYY-MM-DDTHH:MM:SS.fff+0000')
+      orjson serializes datetime natively (bypassing default()), producing
+      inconsistent formats. Converting to string first ensures correct output.
+    - int outside 64-bit range → str
+      orjson only supports [−2^63, 2^64−1]; large integers raise TypeError.
 
-    date objects are left as-is — orjson serializes them as 'YYYY-MM-DD'.
+    date objects pass through untouched — orjson emits them as 'YYYY-MM-DD'.
+    All other scalars (str, float, bool, None, Decimal, etc.) pass through.
     """
     if isinstance(obj, datetime.datetime):
         return _fmt_datetime(obj)
+    elif isinstance(obj, int):
+        if obj > UINT64_MAX or obj < INT64_MIN:
+            return str(obj)
+        return obj
     elif isinstance(obj, dict):
-        return {key: _convert_datetimes(value) for key, value in obj.items()}
+        return {key: _normalize_obj(value) for key, value in obj.items()}
     elif isinstance(obj, (list, tuple)):
-        return type(obj)(_convert_datetimes(item) for item in obj)
+        return type(obj)(_normalize_obj(item) for item in obj)
     else:
         return obj
 
@@ -86,21 +71,11 @@ def envoxy_json_dumps(obj):
     """
     Serialize object to JSON bytes using orjson.
 
-    orjson handles datetime natively (bypassing the default function), so we
-    pre-process the object tree to normalize all datetime values to the platform
-    UTC format (YYYY-MM-DDTHH:MM:SS.fff+0000) before serialization.
-
-    Also handles large integers (exceeding 64-bit range) by converting them to
-    strings on TypeError, using a try-fast-path to minimize overhead.
+    Pre-processes the object tree with _normalize_obj (single pass) to handle:
+    - datetime → platform UTC string (orjson bypasses default() for datetime)
+    - int outside 64-bit range → str (orjson raises TypeError for these)
     """
-    obj = _convert_datetimes(obj)
-    try:
-        return orjson.dumps(obj, default=envoxy_json_encode_default)
-    except TypeError as e:
-        if "Integer exceeds 64-bit range" in str(e):
-            obj = _convert_large_integers(obj)
-            return orjson.dumps(obj, default=envoxy_json_encode_default)
-        raise
+    return orjson.dumps(_normalize_obj(obj), default=envoxy_json_encode_default)
 
 
 def envoxy_json_loads(obj):

--- a/src/envoxy/utils/encoders.py
+++ b/src/envoxy/utils/encoders.py
@@ -36,6 +36,33 @@ def _convert_large_integers(obj):
         return obj
 
 
+def _fmt_datetime(dt):
+    """Format a datetime to platform UTC format: YYYY-MM-DDTHH:MM:SS.fff+0000."""
+    dt_utc = dt if dt.tzinfo is None else dt.astimezone(datetime.timezone.utc)
+    return dt_utc.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "+0000"
+
+
+def _convert_datetimes(obj):
+    """
+    Recursively convert datetime objects to the platform UTC string format.
+
+    orjson serializes datetime natively (bypassing the default function),
+    producing inconsistent formats (+00:00, 6 decimal places, non-UTC offsets).
+    Pre-processing ensures all datetime values are normalized before orjson
+    sees them.
+
+    date objects are left as-is — orjson serializes them as 'YYYY-MM-DD'.
+    """
+    if isinstance(obj, datetime.datetime):
+        return _fmt_datetime(obj)
+    elif isinstance(obj, dict):
+        return {key: _convert_datetimes(value) for key, value in obj.items()}
+    elif isinstance(obj, (list, tuple)):
+        return type(obj)(_convert_datetimes(item) for item in obj)
+    else:
+        return obj
+
+
 def envoxy_json_encode_default(obj):
     if isinstance(obj, decimal.Decimal):
         return float(obj)
@@ -59,20 +86,20 @@ def envoxy_json_dumps(obj):
     """
     Serialize object to JSON bytes using orjson.
 
-    Automatically handles large integers (exceeding 64-bit range) by converting
-    them to strings. Uses a try-fast-path approach: attempts direct serialization
-    first, only pre-processing on TypeError to minimize overhead for common cases.
+    orjson handles datetime natively (bypassing the default function), so we
+    pre-process the object tree to normalize all datetime values to the platform
+    UTC format (YYYY-MM-DDTHH:MM:SS.fff+0000) before serialization.
+
+    Also handles large integers (exceeding 64-bit range) by converting them to
+    strings on TypeError, using a try-fast-path to minimize overhead.
     """
+    obj = _convert_datetimes(obj)
     try:
-        # Fast path: try direct serialization (works for 99% of cases)
         return orjson.dumps(obj, default=envoxy_json_encode_default)
     except TypeError as e:
-        # Check if it's an integer overflow issue
         if "Integer exceeds 64-bit range" in str(e):
-            # Slow path: pre-process to convert large integers to strings
             obj = _convert_large_integers(obj)
             return orjson.dumps(obj, default=envoxy_json_encode_default)
-        # Re-raise if it's a different TypeError
         raise
 
 

--- a/tests/unit/test_encoders.py
+++ b/tests/unit/test_encoders.py
@@ -151,7 +151,7 @@ class TestEnvoxyJsonEncodeDefault:
         assert decoded["large_int"] == "18446744073709551616"
         assert decoded["float"] == 3.14
         assert decoded["decimal"] == 123.45
-        assert decoded["datetime"] == "2025-12-05T10:30:45"
+        assert decoded["datetime"] == "2025-12-05T10:30:45.000+0000"
         assert decoded["date"] == "2025-12-05"
         assert decoded["string"] == "test"
         assert decoded["bool"] is True
@@ -176,7 +176,7 @@ class TestEnvoxyJsonDumpsLoads:
         data = {"timestamp": dt}
         encoded = envoxy_json_dumps(data)
         decoded = envoxy_json_loads(encoded)
-        assert decoded["timestamp"] == "2025-12-05T10:30:45"
+        assert decoded["timestamp"] == "2025-12-05T10:30:45.000+0000"
 
     @pytest.mark.unit
     def test_bytes_output(self):

--- a/tests/unit/test_encoders.py
+++ b/tests/unit/test_encoders.py
@@ -25,11 +25,11 @@ class TestEnvoxyJsonEncoder:
         assert isinstance(result, float)
 
     def test_datetime_encoding(self):
-        """Test that datetime values are encoded as ISO format strings."""
+        """Test that datetime values are encoded as UTC platform format strings."""
         encoder = EnvoxyJsonEncoder()
         dt = datetime.datetime(2025, 12, 5, 10, 30, 45)
         result = encoder.default(dt)
-        assert result == "2025-12-05T10:30:45"
+        assert result == "2025-12-05T10:30:45.000+0000"
 
     def test_date_encoding(self):
         """Test that date values are encoded as ISO format strings."""
@@ -49,10 +49,10 @@ class TestEnvoxyJsonEncodeDefault:
         assert isinstance(result, float)
 
     def test_datetime_encoding(self):
-        """Test that datetime values are encoded as ISO format strings."""
+        """Test that datetime values are encoded as UTC platform format strings."""
         dt = datetime.datetime(2025, 12, 5, 10, 30, 45)
         result = envoxy_json_encode_default(dt)
-        assert result == "2025-12-05T10:30:45"
+        assert result == "2025-12-05T10:30:45.000+0000"
 
     def test_date_encoding(self):
         """Test that date values are encoded as ISO format strings."""


### PR DESCRIPTION
This pull request standardizes the encoding of `datetime` values across the codebase to a consistent UTC platform format (`YYYY-MM-DDTHH:MM:SS.fff+0000`), updates the JSON serialization logic to use this format, and improves handling of special types for serialization. Associated tests are updated to reflect these changes.

**Datetime encoding standardization:**

* Introduced `_fmt_datetime` helper and updated all `datetime` serialization (including `envoxy_json_encode_default`, `EnvoxyJsonEncoder`, and PostgreSQL query row normalization) to use the UTC platform format `YYYY-MM-DDTHH:MM:SS.fff+0000`. (`src/envoxy/utils/encoders.py`, `src/envoxy/postgresql/client.py`) [[1]](diffhunk://#diff-f25696fc6fd9023826a29a1bc6cdea01b628a594ce21c78fbdb973969baa4fe4L16-R24) [[2]](diffhunk://#diff-f25696fc6fd9023826a29a1bc6cdea01b628a594ce21c78fbdb973969baa4fe4L42-R78) [[3]](diffhunk://#diff-f25696fc6fd9023826a29a1bc6cdea01b628a594ce21c78fbdb973969baa4fe4L81-R99) [[4]](diffhunk://#diff-3034468882765ea6a0503cf72f2fe7e0382a8040bc69f3cd576ffb491ec1328aR27-R43) [[5]](diffhunk://#diff-3034468882765ea6a0503cf72f2fe7e0382a8040bc69f3cd576ffb491ec1328aL444-R463)

**JSON serialization improvements:**

* Enabled orjson's `OPT_PASSTHROUGH_DATETIME` option to ensure all `datetime`/`date` objects are routed through the custom encoder for consistent formatting. (`src/envoxy/utils/encoders.py`)
* Improved handling of `MappingView` types (e.g., `dict_keys`, `dict_values`) to allow serialization of more Python native types. (`src/envoxy/utils/encoders.py`)

**Testing updates:**

* Updated unit tests to expect the new UTC platform datetime format in all relevant assertions and docstrings. (`tests/unit/test_encoders.py`) [[1]](diffhunk://#diff-b65df8af0e290334c36b440e328a8199c51942eb4a24f7692dcad471e0292797L28-R32) [[2]](diffhunk://#diff-b65df8af0e290334c36b440e328a8199c51942eb4a24f7692dcad471e0292797L52-R55) [[3]](diffhunk://#diff-b65df8af0e290334c36b440e328a8199c51942eb4a24f7692dcad471e0292797L154-R154) [[4]](diffhunk://#diff-b65df8af0e290334c36b440e328a8199c51942eb4a24f7692dcad471e0292797L179-R179)

**Dependency and import adjustments:**

* Added missing import of `date` in relevant modules to support new serialization logic. (`src/envoxy/postgresql/client.py`, `src/envoxy/utils/encoders.py`) [[1]](diffhunk://#diff-3034468882765ea6a0503cf72f2fe7e0382a8040bc69f3cd576ffb491ec1328aL7-R7) [[2]](diffhunk://#diff-f25696fc6fd9023826a29a1bc6cdea01b628a594ce21c78fbdb973969baa4fe4R4)