### PR TITLE
chore: bump version to 0.6.22 / envoxyd 0.5.22

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "envoxy"
-version = "0.6.21"
+version = "0.6.22"
 description = "Envoxy Platform Framework"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/vendors/pyproject.toml
+++ b/vendors/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "envoxyd"
-version = "0.5.21"
+version = "0.5.22"
 description = "Customized uWSGI server for Envoxy"
 requires-python = ">=3.12"
 authors = [


### PR DESCRIPTION
This pull request includes minor version bumps for both the main project and a vendor package to reflect recent changes.

- Version updates:
  * Bumped the `envoxy` package version from `0.6.21` to `0.6.22` in `pyproject.toml`.
  * Bumped the `envoxyd` vendor package version from `0.5.21` to `0.5.22` in `vendors/pyproject.toml`.