### PR TITLE
Feature/clickhouse

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "envoxy"
-version = "0.6.22"
+version = "0.7.0"
 description = "Envoxy Platform Framework"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -43,6 +43,7 @@ dependencies = [
     "celerybeat-mongo==0.2.0",
     "inflect==7.5.0",
     "alembic==1.17.0",
+    "clickhouse-connect>=1.0.1",
 ]
 
 [project.optional-dependencies]

--- a/src/envoxy/__init__.py
+++ b/src/envoxy/__init__.py
@@ -1,4 +1,4 @@
-# ruff: noqa: F403,F401,F405
+# ruff: noqa: F403,F401,F405,E402
 
 # CRITICAL: Process .pth files for editable installs BEFORE any other imports
 # This must run in each worker process (after fork), not just in the master

--- a/src/envoxy/__init__.py
+++ b/src/envoxy/__init__.py
@@ -149,6 +149,7 @@ from .db.dispatcher import (
     PgDispatcher as pgsqlc,
     CouchDBDispatcher as couchdbc,
     RedisDBDispatcher as redisc,
+    ClickHouseDispatcher as chsqlc,
 )
 from .auth.backends import authenticate_container as authenticate
 from .mqtt.dispatcher import Dispatcher as mqttc

--- a/src/envoxy/clickhouse/__init__.py
+++ b/src/envoxy/clickhouse/__init__.py
@@ -1,0 +1,2 @@
+# ruff: noqa: F401
+from .client import Client

--- a/src/envoxy/clickhouse/client.py
+++ b/src/envoxy/clickhouse/client.py
@@ -85,7 +85,7 @@ _DEFAULT_SESSION_SETTINGS: dict = {
 
 # Per-query defaults that callers can override via `query_settings=`.
 _DEFAULT_QUERY_SETTINGS: dict = {
-    "max_execution_time": 30,     # seconds before server cancels the query
+    "max_execution_time": 30,  # seconds before server cancels the query
 }
 
 # Retry knobs for transient connectivity failures.
@@ -96,6 +96,7 @@ _DEFAULT_RETRY_DELAY = 1  # seconds (doubles on each attempt)
 # ---------------------------------------------------------------------------
 # Result normalisation
 # ---------------------------------------------------------------------------
+
 
 def _normalize_value(value: object) -> object:
     """Convert a single ClickHouse-typed value to a platform-standard type.
@@ -128,6 +129,7 @@ def _normalize_row(columns: tuple, row: tuple) -> dict:
 # Client
 # ---------------------------------------------------------------------------
 
+
 class Client:
     """
     Singleton ClickHouse client for Envoxy — read-only queries only.
@@ -138,7 +140,9 @@ class Client:
     """
 
     _instance = None
-    _lock = RLock()  # Reentrant: reload_config holds the lock and calls _connect which re-acquires it
+    _lock = (
+        RLock()
+    )  # Reentrant: reload_config holds the lock and calls _connect which re-acquires it
 
     def __new__(cls, *args, **kwargs):
         with cls._lock:
@@ -223,7 +227,7 @@ class Client:
                     compress=bool(conf.get("compress", True)),
                     # HTTP-level socket timeout; ClickHouse server-side timeout
                     # is enforced separately via max_execution_time.
-                    query_limit=0,       # no client-side row cap
+                    query_limit=0,  # no client-side row cap
                     settings=session_settings,
                 )
                 # Verify the connection is actually reachable.
@@ -341,7 +345,9 @@ class Client:
         for attempt in range(attempts):
             try:
                 ch_client = self._get_client(server_key)
-                result = ch_client.query(sql_query, parameters=params, settings=settings)
+                result = ch_client.query(
+                    sql_query, parameters=params, settings=settings
+                )
                 columns = result.column_names
                 return [_normalize_row(columns, row) for row in result.result_rows]
 
@@ -360,9 +366,7 @@ class Client:
                 try:
                     self._connect(self._instances[server_key])
                 except Exception as reconnect_exc:
-                    Log.error(
-                        f"[CH:{server_key}] Reconnect failed: {reconnect_exc!r}"
-                    )
+                    Log.error(f"[CH:{server_key}] Reconnect failed: {reconnect_exc!r}")
                 sleep(delay * math.pow(2, attempt))
 
         raise DatabaseException(

--- a/src/envoxy/clickhouse/client.py
+++ b/src/envoxy/clickhouse/client.py
@@ -1,0 +1,423 @@
+# ruff: noqa: F401
+"""
+ClickHouse read-only client for Envoxy.
+
+Design goals and ClickHouse-specific best practices applied here:
+
+1. Read-only by contract — no insert/update/delete methods exist.
+   At the protocol level `readonly=2` is passed as a session setting so that
+   the server itself will reject any data-modification attempt even if a caller
+   constructs a raw INSERT/ALTER query string.
+
+2. One HTTP client per server key — `clickhouse_connect` already manages an
+   internal urllib3 connection pool over HTTP(S). We wrap it in a singleton
+   dict keyed by server_key rather than building another pool on top.
+
+3. Retry with exponential back-off — only on transient/network errors
+   (`OperationalError`).  Query-level errors (`DatabaseError`, bad SQL, type
+   mismatches) propagate immediately so callers can react.
+
+4. HTTP compression enabled by default — ClickHouse supports LZ4 / ZSTD
+   compression at the HTTP layer.  For analytics payloads (large COUNT/GROUP BY
+   result sets) this reduces transfer time significantly.
+
+5. Per-query settings — callers can pass `query_settings` to override defaults
+   on a single call (e.g. raise `max_execution_time` for a heavy report).
+
+6. Uniform result shape — results are always `list[dict]` with Python-native
+   types, matching the shape returned by the PostgreSQL client so that upper
+   layers need no branching.
+
+7. Type normalisation — ClickHouse returns `Decimal`, `uuid.UUID`, `datetime`,
+   and `date` objects.  All are converted to the platform's standard wire
+   format (strings / floats) so JSON serialisers and downstream code work
+   without extra handling.
+
+8. Health check via `client.ping()` — used on startup and optionally on retry.
+
+Configuration block expected under `clickhouse_servers` in the app config:
+
+    "clickhouse_servers": {
+        "<server_key>": {
+            "host":               "ch.example.com",
+            "port":               8123,       # 8443 for HTTPS
+            "db":                 "raw",       # default database
+            "username":           "default",
+            "passwd":             "",
+            "secure":             false,       # true → HTTPS
+            "compress":           true,        # HTTP-level compression
+            "query_timeout":      30,          # HTTP socket timeout (seconds)
+            "max_execution_time": 30,          # ClickHouse server-side timeout
+            "max_threads":        4            # server-side query parallelism
+        }
+    }
+"""
+
+import math
+import uuid
+import decimal
+from time import sleep
+from threading import RLock
+from datetime import datetime, date, timezone
+
+try:
+    import clickhouse_connect
+    from clickhouse_connect.driver.exceptions import OperationalError, DatabaseError
+except ImportError as _exc:  # pragma: no cover
+    raise ImportError(
+        "clickhouse-connect is required for the ClickHouse client. "
+        "Install it with: pip install clickhouse-connect"
+    ) from _exc
+
+from ..db.exceptions import DatabaseException
+from ..utils.logs import Log
+from ..constants import TIMEOUT_CONN
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+# Session-level settings applied to every query unless overridden.
+#   readonly=2  → server rejects INSERT/ALTER/DROP but allows SET (query opts)
+_DEFAULT_SESSION_SETTINGS: dict = {
+    "readonly": 2,
+}
+
+# Per-query defaults that callers can override via `query_settings=`.
+_DEFAULT_QUERY_SETTINGS: dict = {
+    "max_execution_time": 30,     # seconds before server cancels the query
+}
+
+# Retry knobs for transient connectivity failures.
+_DEFAULT_RETRIES = 3
+_DEFAULT_RETRY_DELAY = 1  # seconds (doubles on each attempt)
+
+
+# ---------------------------------------------------------------------------
+# Result normalisation
+# ---------------------------------------------------------------------------
+
+def _normalize_value(value: object) -> object:
+    """Convert a single ClickHouse-typed value to a platform-standard type.
+
+    ClickHouse-specific conversions:
+    - ``datetime`` (DateTime / DateTime64)   → "YYYY-MM-DDTHH:MM:SS.fff+0000"
+    - ``date``     (Date / Date32)           → "YYYY-MM-DD"
+    - ``Decimal``  (Decimal32/64/128/256)    → float
+    - ``uuid.UUID``                          → str (lowercase with dashes)
+    - Everything else (int, float, str, bool, None) passes through unchanged.
+    """
+    if isinstance(value, datetime):
+        dt_utc = value if value.tzinfo is None else value.astimezone(timezone.utc)
+        return dt_utc.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "+0000"
+    if isinstance(value, date):
+        return value.isoformat()
+    if isinstance(value, decimal.Decimal):
+        return float(value)
+    if isinstance(value, uuid.UUID):
+        return str(value)
+    return value
+
+
+def _normalize_row(columns: tuple, row: tuple) -> dict:
+    """Zip column names and values into a normalised dict."""
+    return {col: _normalize_value(val) for col, val in zip(columns, row)}
+
+
+# ---------------------------------------------------------------------------
+# Client
+# ---------------------------------------------------------------------------
+
+class Client:
+    """
+    Singleton ClickHouse client for Envoxy — read-only queries only.
+
+    One ``clickhouse_connect.Client`` instance is kept alive per server key.
+    The underlying HTTP client manages its own urllib3 connection pool; this
+    wrapper adds retry logic, type normalisation, and unified logging on top.
+    """
+
+    _instance = None
+    _lock = RLock()  # Reentrant: reload_config holds the lock and calls _connect which re-acquires it
+
+    def __new__(cls, *args, **kwargs):
+        with cls._lock:
+            if cls._instance is None:
+                cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __init__(self, server_conf: dict):
+        # Guard against re-initialisation in the singleton pattern.
+        if getattr(self, "_initialized", False):
+            return
+        self._initialized = True
+
+        self._instances: dict = {}
+
+        for server_key, conf in server_conf.items():
+            with self._lock:
+                self._instances[server_key] = {
+                    "server": server_key,
+                    "conf": conf,
+                }
+            self._connect(self._instances[server_key])
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _connect(
+        self,
+        instance: dict,
+        reconnect_attempts: int = _DEFAULT_RETRIES,
+        reconnect_delay: float = _DEFAULT_RETRY_DELAY,
+    ) -> None:
+        """Create and store a ``clickhouse_connect.Client`` for *instance*."""
+
+        conf = instance["conf"]
+
+        # Build session-level settings: enforce read-only plus any extras from
+        # the config (e.g. max_threads, max_result_rows).
+        session_settings = dict(_DEFAULT_SESSION_SETTINGS)
+        if "max_threads" in conf:
+            session_settings["max_threads"] = int(conf["max_threads"])
+
+        ch_client = self._retry_connect(
+            conf=conf,
+            session_settings=session_settings,
+            attempts=reconnect_attempts,
+            delay=reconnect_delay,
+        )
+
+        with self._lock:
+            instance["ch_client"] = ch_client
+
+        Log.trace(
+            ">>> Connected to CLICKHOUSE: {}, {}:{}".format(
+                instance["server"],
+                conf.get("host", "localhost"),
+                conf.get("port", 8123),
+            )
+        )
+
+    def _retry_connect(
+        self,
+        conf: dict,
+        session_settings: dict,
+        attempts: int,
+        delay: float,
+    ):
+        """Attempt to create a ClickHouse HTTP client, retrying on failure."""
+
+        last_exc: Exception | None = None
+
+        for attempt in range(attempts):
+            try:
+                ch_client = clickhouse_connect.get_client(
+                    host=conf.get("host", "localhost"),
+                    port=int(conf.get("port", 8123)),
+                    username=conf.get("username", "default"),
+                    password=conf.get("passwd", ""),
+                    database=conf.get("db", "default"),
+                    secure=bool(conf.get("secure", False)),
+                    compress=bool(conf.get("compress", True)),
+                    # HTTP-level socket timeout; ClickHouse server-side timeout
+                    # is enforced separately via max_execution_time.
+                    query_limit=0,       # no client-side row cap
+                    settings=session_settings,
+                )
+                # Verify the connection is actually reachable.
+                if not ch_client.ping():
+                    raise OperationalError("ClickHouse ping failed")
+                return ch_client
+
+            except Exception as exc:
+                last_exc = exc
+                Log.error(
+                    f"[CH] Connection attempt {attempt + 1}/{attempts} failed: {exc!r}"
+                )
+                sleep(delay * math.pow(2, attempt))
+
+        raise DatabaseException(
+            f"[CH] Failed to connect after {attempts} attempts: {last_exc}"
+        ) from last_exc
+
+    def _get_client(self, server_key: str):
+        """Return the live ``clickhouse_connect.Client`` for *server_key*."""
+
+        instance = self._instances.get(server_key)
+
+        if instance is None:
+            raise DatabaseException(
+                f"[CH] No configuration found for server key: '{server_key}'"
+            )
+
+        ch_client = instance.get("ch_client")
+
+        if ch_client is None:
+            # Lazy initialisation guard (should not normally happen).
+            self._connect(instance)
+            ch_client = instance["ch_client"]
+
+        return ch_client
+
+    def _is_healthy(self, server_key: str) -> bool:
+        """Ping the server and return True if it responds."""
+        try:
+            return self._get_client(server_key).ping()
+        except Exception:
+            return False
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def query(
+        self,
+        server_key: str,
+        sql_query: str,
+        params: dict | None = None,
+        query_settings: dict | None = None,
+    ) -> list[dict]:
+        """
+        Execute a read-only SQL query and return results as ``list[dict]``.
+
+        Parameters
+        ----------
+        server_key:
+            Identifier matching a key in ``clickhouse_servers`` config.
+        sql_query:
+            ClickHouse SQL string.  Use ``{name:Type}`` placeholders for
+            parameters (e.g. ``WHERE app_id = {application_id:String}``).
+        params:
+            Dict of named parameters to bind — values are Python-typed and
+            the library converts them to ClickHouse wire format automatically.
+        query_settings:
+            Optional per-query ClickHouse settings that override the defaults
+            (e.g. ``{"max_execution_time": 120}`` for a heavier report).
+
+        Returns
+        -------
+        list[dict]
+            Each dict maps column name → normalised Python value.  The shape
+            matches what the PostgreSQL client returns so callers need no
+            special-casing.
+
+        Raises
+        ------
+        DatabaseException
+            On connection failure after retries, or when no config exists for
+            *server_key*.
+        clickhouse_connect.driver.exceptions.DatabaseError
+            Propagated directly for bad SQL, type errors, or permission
+            violations — these are not retried.
+        """
+
+        if not sql_query or not sql_query.strip():
+            raise DatabaseException("[CH] SQL query cannot be empty")
+
+        _params = params or {}
+
+        # Merge default query settings with caller overrides.
+        _settings = dict(_DEFAULT_QUERY_SETTINGS)
+        if query_settings:
+            _settings.update(query_settings)
+
+        return self._execute_with_retry(server_key, sql_query, _params, _settings)
+
+    def _execute_with_retry(
+        self,
+        server_key: str,
+        sql_query: str,
+        params: dict,
+        settings: dict,
+        attempts: int = _DEFAULT_RETRIES,
+        delay: float = _DEFAULT_RETRY_DELAY,
+    ) -> list[dict]:
+        """Run the query, reconnecting on transient errors."""
+
+        last_exc: Exception | None = None
+
+        for attempt in range(attempts):
+            try:
+                ch_client = self._get_client(server_key)
+                result = ch_client.query(sql_query, parameters=params, settings=settings)
+                columns = result.column_names
+                return [_normalize_row(columns, row) for row in result.result_rows]
+
+            except DatabaseError:
+                # Bad SQL / type error / access violation — don't retry, let it
+                # bubble up so the caller gets a clear error message.
+                raise
+
+            except Exception as exc:
+                # Transient connectivity error — attempt to reconnect and retry.
+                last_exc = exc
+                Log.error(
+                    f"[CH:{server_key}] Query attempt {attempt + 1}/{attempts} failed: "
+                    f"{exc!r}. Reconnecting…"
+                )
+                try:
+                    self._connect(self._instances[server_key])
+                except Exception as reconnect_exc:
+                    Log.error(
+                        f"[CH:{server_key}] Reconnect failed: {reconnect_exc!r}"
+                    )
+                sleep(delay * math.pow(2, attempt))
+
+        raise DatabaseException(
+            f"[CH:{server_key}] Query failed after {attempts} attempts: {last_exc}"
+        ) from last_exc
+
+    def reload_config(self, server_conf: dict) -> None:
+        """
+        Hot-reload server configuration without restarting the process.
+
+        - New keys are connected immediately.
+        - Existing keys whose config changed get a fresh client.
+        - Removed keys have their client closed gracefully.
+        """
+
+        with self._lock:
+            existing_keys = set(self._instances)
+            new_keys = set(server_conf)
+
+            # Close clients for removed servers.
+            for removed_key in existing_keys - new_keys:
+                self._close_client(self._instances.pop(removed_key, {}))
+
+            for server_key, conf in server_conf.items():
+                if server_key in self._instances:
+                    old_conf = self._instances[server_key]["conf"]
+                    if old_conf != conf:
+                        # Config changed — close the old client and reconnect.
+                        self._close_client(self._instances[server_key])
+                        self._instances[server_key]["conf"] = conf
+                        try:
+                            self._connect(self._instances[server_key])
+                        except Exception as exc:
+                            Log.error(
+                                f"[CH] Failed to reconnect '{server_key}' "
+                                f"after config change: {exc!r}"
+                            )
+                else:
+                    self._instances[server_key] = {
+                        "server": server_key,
+                        "conf": conf,
+                    }
+                    try:
+                        self._connect(self._instances[server_key])
+                    except Exception as exc:
+                        Log.error(
+                            f"[CH] Failed to connect new server '{server_key}': {exc!r}"
+                        )
+
+    @staticmethod
+    def _close_client(instance: dict) -> None:
+        """Best-effort close of a ``clickhouse_connect.Client``."""
+        ch_client = instance.get("ch_client")
+        if ch_client is not None:
+            try:
+                ch_client.close()
+            except Exception as exc:
+                Log.error(f"[CH] Error closing client: {exc!r}")

--- a/src/envoxy/db/dispatcher.py
+++ b/src/envoxy/db/dispatcher.py
@@ -10,6 +10,7 @@ from ..utils.config import Config
 from ..postgresql.client import Client as PgClient
 from ..couchdb.client import Client as CouchDBClient
 from ..redis.client import Client as RedisDBClient
+from ..clickhouse.client import Client as ClickHouseClient
 from ..db.orm import get_manager, session_scope, transactional, get_default_server_key
 
 
@@ -34,6 +35,16 @@ class Connector(Singleton):
             pgsql_client: The client instance for interacting with the PostgreSQL database.
         """
         return self.pgsql_client
+
+    @property
+    def clickhouse(self):
+        """
+        Returns the ClickHouse client instance.
+
+        Returns:
+            ClickHouseClient: The read-only client for ClickHouse analytics queries.
+        """
+        return self.clickhouse_client
 
     @property
     def couchdb(self):
@@ -109,6 +120,26 @@ class Connector(Singleton):
 
         self.redis_client = RedisDBClient(self._redis_confs)
 
+    def start_clickhouse_conn(self):
+        """
+        Initializes a ClickHouse client using configuration settings.
+
+        Retrieves ClickHouse server configurations from ``clickhouse_servers`` in
+        the application config.  Raises an exception if the key is missing.
+        Instantiates a ``ClickHouseClient`` and assigns it to
+        ``self.clickhouse_client``.
+
+        The ClickHouse client is read-only by design: no insert / update /
+        delete methods are exposed.
+        """
+
+        self._ch_confs = Config.get("clickhouse_servers")
+
+        if not self._ch_confs:
+            raise Exception("Error to find ClickHouse Servers config")
+
+        self.clickhouse_client = ClickHouseClient(self._ch_confs)
+
 
 class CouchConnector(Connector):
     """
@@ -150,6 +181,24 @@ class RedisConnector(Connector):
 
     def __init__(self):
         self.start_redis_conn()
+
+
+class ChConnector(Connector):
+    """
+    ChConnector manages a read-only ClickHouse client singleton.
+
+    Reads configuration from ``clickhouse_servers`` in the app config and
+    instantiates a ``ClickHouseClient`` that enforces read-only access at the
+    protocol level (``readonly=2``).
+
+    Methods
+    -------
+    __init__():
+        Initializes the connector by calling ``start_clickhouse_conn()``.
+    """
+
+    def __init__(self):
+        self.start_clickhouse_conn()
 
 
 class PgDispatcher:
@@ -350,3 +399,79 @@ class RedisDBDispatcher:
             redis.client.Redis: A Redis client instance connected to the specified server.
         """
         return RedisConnector.instance().redis.get_client(server_key)
+
+
+class ClickHouseDispatcher:
+    """
+    Static interface for executing read-only analytics queries against ClickHouse.
+
+    This dispatcher mirrors the shape of ``PgDispatcher`` so that call sites can
+    swap between the two with minimal friction.  Only ``query()`` is exposed —
+    there are intentionally no insert / update / delete / transaction methods.
+
+    Usage::
+
+        from envoxy import chsqlc
+
+        results = chsqlc.query(
+            "analytics",
+            "SELECT COUNT(*) AS count FROM raw.policies WHERE toString(application_id) = {app_id:String}",
+            params={"app_id": "some-uuid"},
+        )
+        # results → [{"count": 42}]
+
+    Per-query ClickHouse settings can be overridden::
+
+        results = chsqlc.query(
+            "analytics",
+            heavy_sql,
+            params=params,
+            query_settings={"max_execution_time": 120, "max_threads": 8},
+        )
+    """
+
+    @staticmethod
+    def query(
+        server_key: str,
+        sql: str,
+        params: dict | None = None,
+        query_settings: dict | None = None,
+    ) -> list[dict]:
+        """
+        Execute a read-only SQL query against ClickHouse.
+
+        Args:
+            server_key (str):
+                Config key matching an entry under ``clickhouse_servers``.
+            sql (str):
+                ClickHouse SQL.  Use ``{name:Type}`` placeholders for
+                parameter binding (e.g. ``{app_id:String}``).
+            params (dict | None):
+                Named parameters bound to the query.  Values are Python-typed;
+                ``clickhouse_connect`` converts them to the correct wire format.
+            query_settings (dict | None):
+                Optional per-query ClickHouse server settings, e.g.
+                ``{"max_execution_time": 120}``.  Merged on top of the
+                client-level defaults.
+
+        Returns:
+            list[dict]: Each dict maps column name → normalised Python value.
+
+        Raises:
+            DatabaseException: On connection failure or missing config.
+            clickhouse_connect.driver.exceptions.DatabaseError:
+                Propagated directly for query-level errors (bad SQL, etc.).
+        """
+        return ChConnector.instance().clickhouse.query(
+            server_key, sql, params, query_settings
+        )
+
+    @staticmethod
+    def client() -> "ClickHouseClient":
+        """
+        Return the underlying ``ClickHouseClient`` instance for advanced usage.
+
+        Returns:
+            ClickHouseClient: The singleton client instance.
+        """
+        return ChConnector.instance().clickhouse

--- a/src/envoxy/postgresql/client.py
+++ b/src/envoxy/postgresql/client.py
@@ -458,9 +458,7 @@ class Client:
                     _rowcount = _cursor.rowcount
                     _rows = _cursor.fetchall()
 
-                    _data.extend(
-                        [_normalize_row(dict(row)) for row in _rows]
-                    )
+                    _data.extend([_normalize_row(dict(row)) for row in _rows])
 
                     _offset_limit += _chunk_size
                     _local_params.update({"offset_limit": _offset_limit})

--- a/src/envoxy/tests/test_clickhouse_client.py
+++ b/src/envoxy/tests/test_clickhouse_client.py
@@ -1,0 +1,485 @@
+# ruff: noqa: F401,F821
+"""
+Unit tests for the ClickHouse client (envoxy.clickhouse.client).
+
+All tests are fully isolated — no real ClickHouse connection is required.
+External calls to ``clickhouse_connect.get_client`` are monkeypatched with
+lightweight fakes that cover the expected contract.
+"""
+
+import decimal
+import uuid
+from datetime import date, datetime, timezone
+from threading import Thread
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from envoxy.clickhouse.client import (
+    Client,
+    _normalize_row,
+    _normalize_value,
+)
+from envoxy.db.exceptions import DatabaseException
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fakes
+# ---------------------------------------------------------------------------
+
+def _make_query_result(columns: tuple, rows: list[tuple]):
+    """Build a minimal fake ``QueryResult`` returned by clickhouse_connect."""
+    result = MagicMock()
+    result.column_names = columns
+    result.result_rows = rows
+    return result
+
+
+class FakeChClient:
+    """Minimal fake of ``clickhouse_connect.Client``."""
+
+    def __init__(self, rows=None, columns=None, raise_on_query=None, ping_ok=True):
+        self._rows = rows or [(1,)]
+        self._columns = columns or ("count",)
+        self._raise_on_query = raise_on_query
+        self._ping_ok = ping_ok
+        self.close_called = False
+        self.queries: list[tuple] = []   # (sql, parameters, settings)
+
+    def ping(self) -> bool:
+        return self._ping_ok
+
+    def query(self, sql, parameters=None, settings=None):
+        self.queries.append((sql, parameters, settings))
+        if self._raise_on_query:
+            raise self._raise_on_query
+        return _make_query_result(self._columns, self._rows)
+
+    def close(self):
+        self.close_called = True
+
+
+@pytest.fixture(autouse=True)
+def reset_client_singleton():
+    """Reset the Client singleton between tests to ensure isolation."""
+    original = Client._instance
+    Client._instance = None
+    yield
+    Client._instance = original
+
+
+@pytest.fixture
+def fake_ch_client():
+    return FakeChClient(rows=[(42,)], columns=("count",))
+
+
+@pytest.fixture
+def client_instance(fake_ch_client, monkeypatch):
+    """Return a Client wired to a FakeChClient, bypassing real TCP connections."""
+    conf = {
+        "analytics": {
+            "host": "localhost",
+            "port": 8123,
+            "db": "raw",
+            "username": "default",
+            "passwd": "",
+        }
+    }
+
+    with patch("envoxy.clickhouse.client.clickhouse_connect") as mock_cc:
+        mock_cc.get_client.return_value = fake_ch_client
+        c = Client(conf)
+
+    # Inject the fake directly so later calls don't re-create it.
+    c._instances["analytics"]["ch_client"] = fake_ch_client
+    return c, fake_ch_client
+
+
+# ---------------------------------------------------------------------------
+# _normalize_value
+# ---------------------------------------------------------------------------
+
+class TestNormalizeValue:
+
+    def test_datetime_naive_becomes_utc_string(self):
+        dt = datetime(2024, 6, 15, 12, 30, 45, 123456)
+        result = _normalize_value(dt)
+        assert result == "2024-06-15T12:30:45.123+0000"
+
+    def test_datetime_aware_is_converted_to_utc(self):
+        from datetime import timezone as tz, timedelta
+        eastern = timezone(timedelta(hours=-5))
+        dt = datetime(2024, 6, 15, 7, 30, 45, 0, tzinfo=eastern)
+        result = _normalize_value(dt)
+        assert result == "2024-06-15T12:30:45.000+0000"
+
+    def test_date_becomes_isoformat(self):
+        d = date(2024, 1, 31)
+        assert _normalize_value(d) == "2024-01-31"
+
+    def test_decimal_becomes_float(self):
+        d = decimal.Decimal("3.14159")
+        result = _normalize_value(d)
+        assert isinstance(result, float)
+        assert abs(result - 3.14159) < 1e-5
+
+    def test_uuid_becomes_lowercase_string(self):
+        u = uuid.UUID("12345678-1234-5678-1234-567812345678")
+        assert _normalize_value(u) == "12345678-1234-5678-1234-567812345678"
+
+    def test_int_passes_through(self):
+        assert _normalize_value(99) == 99
+
+    def test_float_passes_through(self):
+        assert _normalize_value(1.5) == 1.5
+
+    def test_str_passes_through(self):
+        assert _normalize_value("hello") == "hello"
+
+    def test_none_passes_through(self):
+        assert _normalize_value(None) is None
+
+    def test_bool_passes_through(self):
+        assert _normalize_value(True) is True
+
+
+# ---------------------------------------------------------------------------
+# _normalize_row
+# ---------------------------------------------------------------------------
+
+class TestNormalizeRow:
+
+    def test_produces_dict_with_correct_keys(self):
+        cols = ("id", "state", "count")
+        row = (uuid.UUID("12345678-1234-5678-1234-567812345678"), "active", 10)
+        result = _normalize_row(cols, row)
+        assert result == {
+            "id": "12345678-1234-5678-1234-567812345678",
+            "state": "active",
+            "count": 10,
+        }
+
+    def test_mixed_types_all_normalised(self):
+        cols = ("ts", "amount", "uid")
+        row = (
+            datetime(2024, 1, 1, 0, 0, 0),
+            decimal.Decimal("99.99"),
+            uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        )
+        result = _normalize_row(cols, row)
+        assert result["ts"] == "2024-01-01T00:00:00.000+0000"
+        assert result["amount"] == pytest.approx(99.99)
+        assert result["uid"] == "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+
+
+# ---------------------------------------------------------------------------
+# Client.query — happy paths
+# ---------------------------------------------------------------------------
+
+class TestClientQuery:
+
+    def test_returns_list_of_dicts(self, client_instance):
+        c, fake = client_instance
+        fake._columns = ("id", "name")
+        fake._rows = [("abc", "test")]
+
+        result = c.query("analytics", "SELECT id, name FROM raw.foo")
+
+        assert result == [{"id": "abc", "name": "test"}]
+
+    def test_params_are_forwarded_to_ch_client(self, client_instance):
+        c, fake = client_instance
+        fake._rows = [(1,)]
+        fake._columns = ("count",)
+
+        c.query(
+            "analytics",
+            "SELECT COUNT(*) AS count FROM raw.policies WHERE app_id = {app_id:String}",
+            params={"app_id": "uuid-123"},
+        )
+
+        assert len(fake.queries) == 1
+        _, params, _ = fake.queries[0]
+        assert params == {"app_id": "uuid-123"}
+
+    def test_default_query_settings_applied(self, client_instance):
+        c, fake = client_instance
+        fake._rows = [(0,)]
+        fake._columns = ("n",)
+
+        c.query("analytics", "SELECT 0 AS n")
+
+        _, _, settings = fake.queries[0]
+        assert "max_execution_time" in settings
+        assert settings["max_execution_time"] == 30  # default
+
+    def test_caller_can_override_query_settings(self, client_instance):
+        c, fake = client_instance
+        fake._rows = [(0,)]
+        fake._columns = ("n",)
+
+        c.query(
+            "analytics",
+            "SELECT 0 AS n",
+            query_settings={"max_execution_time": 120, "max_threads": 8},
+        )
+
+        _, _, settings = fake.queries[0]
+        assert settings["max_execution_time"] == 120
+        assert settings["max_threads"] == 8
+
+    def test_empty_result_returns_empty_list(self, client_instance):
+        c, fake = client_instance
+        fake._rows = []
+        fake._columns = ("count",)
+
+        result = c.query("analytics", "SELECT COUNT(*) AS count FROM raw.nothing")
+        assert result == []
+
+    def test_multiple_rows_all_returned(self, client_instance):
+        c, fake = client_instance
+        fake._columns = ("state", "total")
+        fake._rows = [("active", 100), ("canceled", 50)]
+
+        result = c.query("analytics", "SELECT state, total FROM raw.summary")
+        assert len(result) == 2
+        assert result[0] == {"state": "active", "total": 100}
+        assert result[1] == {"state": "canceled", "total": 50}
+
+
+# ---------------------------------------------------------------------------
+# Client.query — error handling
+# ---------------------------------------------------------------------------
+
+class TestClientQueryErrors:
+
+    def test_empty_sql_raises_database_exception(self, client_instance):
+        c, _ = client_instance
+        with pytest.raises(DatabaseException, match="SQL query cannot be empty"):
+            c.query("analytics", "")
+
+    def test_whitespace_only_sql_raises_database_exception(self, client_instance):
+        c, _ = client_instance
+        with pytest.raises(DatabaseException):
+            c.query("analytics", "   ")
+
+    def test_unknown_server_key_raises_database_exception(self, client_instance):
+        c, _ = client_instance
+        with pytest.raises(DatabaseException, match="No configuration found"):
+            c.query("nonexistent", "SELECT 1")
+
+    def test_database_error_propagates_without_retry(self, client_instance, monkeypatch):
+        """DatabaseError (bad SQL) must propagate immediately, no retry."""
+        from clickhouse_connect.driver.exceptions import DatabaseError
+
+        c, fake = client_instance
+        fake._raise_on_query = DatabaseError("syntax error")
+
+        with pytest.raises(DatabaseError):
+            c.query("analytics", "SELECT garbage FROM")
+
+        # Only one attempt — no retry on query-level errors.
+        assert len(fake.queries) == 1
+
+    def test_operational_error_triggers_reconnect_and_retry(
+        self, monkeypatch, fake_ch_client
+    ):
+        """
+        A transient operational error should trigger reconnect + retry.
+        The second attempt succeeds.
+        """
+        conf = {
+            "analytics": {
+                "host": "localhost",
+                "port": 8123,
+                "db": "raw",
+                "username": "default",
+                "passwd": "",
+            }
+        }
+
+        call_count = 0
+        good_result = _make_query_result(("count",), [(7,)])
+
+        def flaky_query(sql, parameters=None, settings=None):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise ConnectionError("transient network error")
+            return good_result
+
+        fake_ch_client.query = flaky_query
+
+        with patch("envoxy.clickhouse.client.clickhouse_connect") as mock_cc:
+            mock_cc.get_client.return_value = fake_ch_client
+            c = Client(conf)
+            c._instances["analytics"]["ch_client"] = fake_ch_client
+
+            # Override sleep to speed up test
+            monkeypatch.setattr("envoxy.clickhouse.client.sleep", lambda _: None)
+
+            result = c.query("analytics", "SELECT COUNT(*) AS count FROM raw.t")
+
+        assert result == [{"count": 7}]
+        assert call_count == 2  # failed once, succeeded on retry
+
+
+# ---------------------------------------------------------------------------
+# Client.reload_config
+# ---------------------------------------------------------------------------
+
+class TestReloadConfig:
+
+    def test_new_server_key_is_connected(self, monkeypatch):
+        conf = {
+            "analytics": {
+                "host": "localhost",
+                "port": 8123,
+                "db": "raw",
+                "username": "default",
+                "passwd": "",
+            }
+        }
+
+        new_fake = FakeChClient()
+
+        with patch("envoxy.clickhouse.client.clickhouse_connect") as mock_cc:
+            mock_cc.get_client.return_value = FakeChClient()
+            c = Client(conf)
+
+            mock_cc.get_client.return_value = new_fake
+
+            c.reload_config(
+                {
+                    "analytics": conf["analytics"],
+                    "reporting": {
+                        "host": "ch2.example.com",
+                        "port": 8123,
+                        "db": "raw",
+                        "username": "default",
+                        "passwd": "",
+                    },
+                }
+            )
+
+        assert "reporting" in c._instances
+
+    def test_removed_server_key_is_closed(self, monkeypatch):
+        conf = {
+            "analytics": {
+                "host": "localhost",
+                "port": 8123,
+                "db": "raw",
+                "username": "default",
+                "passwd": "",
+            },
+            "reporting": {
+                "host": "ch2",
+                "port": 8123,
+                "db": "raw",
+                "username": "default",
+                "passwd": "",
+            },
+        }
+
+        fake_reporting = FakeChClient()
+
+        with patch("envoxy.clickhouse.client.clickhouse_connect") as mock_cc:
+            mock_cc.get_client.return_value = FakeChClient()
+            c = Client(conf)
+            c._instances["reporting"]["ch_client"] = fake_reporting
+
+            # Reload with only "analytics" — "reporting" should be removed + closed.
+            c.reload_config({"analytics": conf["analytics"]})
+
+        assert "reporting" not in c._instances
+        assert fake_reporting.close_called
+
+    def test_changed_config_triggers_reconnect(self, monkeypatch):
+        conf = {
+            "analytics": {
+                "host": "old-host",
+                "port": 8123,
+                "db": "raw",
+                "username": "default",
+                "passwd": "",
+            }
+        }
+
+        old_fake = FakeChClient()
+        new_fake = FakeChClient()
+
+        with patch("envoxy.clickhouse.client.clickhouse_connect") as mock_cc:
+            mock_cc.get_client.return_value = old_fake
+            c = Client(conf)
+            c._instances["analytics"]["ch_client"] = old_fake
+
+            mock_cc.get_client.return_value = new_fake
+
+            c.reload_config(
+                {
+                    "analytics": {
+                        "host": "new-host",  # changed
+                        "port": 8123,
+                        "db": "raw",
+                        "username": "default",
+                        "passwd": "",
+                    }
+                }
+            )
+
+        assert old_fake.close_called
+        assert c._instances["analytics"]["ch_client"] is new_fake
+
+
+# ---------------------------------------------------------------------------
+# Singleton behaviour
+# ---------------------------------------------------------------------------
+
+class TestSingleton:
+
+    def test_two_constructions_return_same_instance(self):
+        conf = {
+            "analytics": {
+                "host": "localhost",
+                "port": 8123,
+                "db": "raw",
+                "username": "default",
+                "passwd": "",
+            }
+        }
+
+        with patch("envoxy.clickhouse.client.clickhouse_connect") as mock_cc:
+            mock_cc.get_client.return_value = FakeChClient()
+            c1 = Client(conf)
+            c2 = Client(conf)
+
+        assert c1 is c2
+
+    def test_singleton_safe_under_concurrent_access(self):
+        conf = {
+            "analytics": {
+                "host": "localhost",
+                "port": 8123,
+                "db": "raw",
+                "username": "default",
+                "passwd": "",
+            }
+        }
+
+        instances = []
+
+        with patch("envoxy.clickhouse.client.clickhouse_connect") as mock_cc:
+            mock_cc.get_client.return_value = FakeChClient()
+
+            def create():
+                instances.append(Client(conf))
+
+            threads = [Thread(target=create) for _ in range(8)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+        # All threads must have received the exact same singleton.
+        assert all(i is instances[0] for i in instances)

--- a/src/envoxy/tests/test_clickhouse_client.py
+++ b/src/envoxy/tests/test_clickhouse_client.py
@@ -27,6 +27,7 @@ from envoxy.db.exceptions import DatabaseException
 # Helpers / fakes
 # ---------------------------------------------------------------------------
 
+
 def _make_query_result(columns: tuple, rows: list[tuple]):
     """Build a minimal fake ``QueryResult`` returned by clickhouse_connect."""
     result = MagicMock()
@@ -44,7 +45,7 @@ class FakeChClient:
         self._raise_on_query = raise_on_query
         self._ping_ok = ping_ok
         self.close_called = False
-        self.queries: list[tuple] = []   # (sql, parameters, settings)
+        self.queries: list[tuple] = []  # (sql, parameters, settings)
 
     def ping(self) -> bool:
         return self._ping_ok
@@ -99,8 +100,8 @@ def client_instance(fake_ch_client, monkeypatch):
 # _normalize_value
 # ---------------------------------------------------------------------------
 
-class TestNormalizeValue:
 
+class TestNormalizeValue:
     def test_datetime_naive_becomes_utc_string(self):
         dt = datetime(2024, 6, 15, 12, 30, 45, 123456)
         result = _normalize_value(dt)
@@ -108,6 +109,7 @@ class TestNormalizeValue:
 
     def test_datetime_aware_is_converted_to_utc(self):
         from datetime import timezone as tz, timedelta
+
         eastern = timezone(timedelta(hours=-5))
         dt = datetime(2024, 6, 15, 7, 30, 45, 0, tzinfo=eastern)
         result = _normalize_value(dt)
@@ -147,8 +149,8 @@ class TestNormalizeValue:
 # _normalize_row
 # ---------------------------------------------------------------------------
 
-class TestNormalizeRow:
 
+class TestNormalizeRow:
     def test_produces_dict_with_correct_keys(self):
         cols = ("id", "state", "count")
         row = (uuid.UUID("12345678-1234-5678-1234-567812345678"), "active", 10)
@@ -176,8 +178,8 @@ class TestNormalizeRow:
 # Client.query — happy paths
 # ---------------------------------------------------------------------------
 
-class TestClientQuery:
 
+class TestClientQuery:
     def test_returns_list_of_dicts(self, client_instance):
         c, fake = client_instance
         fake._columns = ("id", "name")
@@ -251,8 +253,8 @@ class TestClientQuery:
 # Client.query — error handling
 # ---------------------------------------------------------------------------
 
-class TestClientQueryErrors:
 
+class TestClientQueryErrors:
     def test_empty_sql_raises_database_exception(self, client_instance):
         c, _ = client_instance
         with pytest.raises(DatabaseException, match="SQL query cannot be empty"):
@@ -268,7 +270,9 @@ class TestClientQueryErrors:
         with pytest.raises(DatabaseException, match="No configuration found"):
             c.query("nonexistent", "SELECT 1")
 
-    def test_database_error_propagates_without_retry(self, client_instance, monkeypatch):
+    def test_database_error_propagates_without_retry(
+        self, client_instance, monkeypatch
+    ):
         """DatabaseError (bad SQL) must propagate immediately, no retry."""
         from clickhouse_connect.driver.exceptions import DatabaseError
 
@@ -328,8 +332,8 @@ class TestClientQueryErrors:
 # Client.reload_config
 # ---------------------------------------------------------------------------
 
-class TestReloadConfig:
 
+class TestReloadConfig:
     def test_new_server_key_is_connected(self, monkeypatch):
         conf = {
             "analytics": {
@@ -436,8 +440,8 @@ class TestReloadConfig:
 # Singleton behaviour
 # ---------------------------------------------------------------------------
 
-class TestSingleton:
 
+class TestSingleton:
     def test_two_constructions_return_same_instance(self):
         conf = {
             "analytics": {

--- a/src/envoxy/tools/alembic/alembic/env.py
+++ b/src/envoxy/tools/alembic/alembic/env.py
@@ -290,11 +290,17 @@ def _maybe_set_sqlalchemy_url():  # noqa: D401
     # RC file with exported variables (e.g. /etc/zapata/rc.d/muzzley.rc)
     rc_path = os.environ.get("ENVOXY_RC_PATH", "/etc/zapata/rc.d/muzzley.rc")
     if DEBUG:
-        log.warning("[alembic] checking RC file: %s (exists=%s)", rc_path, os.path.isfile(rc_path))
+        log.warning(
+            "[alembic] checking RC file: %s (exists=%s)",
+            rc_path,
+            os.path.isfile(rc_path),
+        )
     if os.path.isfile(rc_path):
         rc_vars = _load_rc_vars(rc_path)
         if DEBUG:
-            log.warning("[alembic] RC vars loaded: %s", "SUCCESS" if rc_vars else "FAILED")
+            log.warning(
+                "[alembic] RC vars loaded: %s", "SUCCESS" if rc_vars else "FAILED"
+            )
             if rc_vars:
                 log.warning("[alembic] RC keys: %s", list(rc_vars.keys()))
         if rc_vars is not None:
@@ -306,8 +312,13 @@ def _maybe_set_sqlalchemy_url():  # noqa: D401
                 rc_vars.get("MUZZLEY_PGSQL_DB") or user
             )  # assume db = user if absent
             if DEBUG:
-                log.warning("[alembic] RC parsed: host=%s, port=%s, user=%s, dbname=%s", 
-                           host, port, user if user else "NONE", dbname if dbname else "NONE")
+                log.warning(
+                    "[alembic] RC parsed: host=%s, port=%s, user=%s, dbname=%s",
+                    host,
+                    port,
+                    user if user else "NONE",
+                    dbname if dbname else "NONE",
+                )
             if host and user and dbname:
                 user_enc = quote_plus(user)
                 pwd_enc = quote_plus(pwd) if pwd else ""
@@ -440,7 +451,7 @@ def run_migrations_online():
 
         with context.begin_transaction():  # type: ignore[attr-defined]
             context.run_migrations()  # type: ignore[attr-defined]
-        
+
         # Explicitly commit the transaction to persist version table updates
         if not context.is_offline_mode():  # type: ignore[attr-defined]
             try:

--- a/src/envoxy/utils/encoders.py
+++ b/src/envoxy/utils/encoders.py
@@ -72,10 +72,16 @@ def envoxy_json_dumps(obj):
     path: first attempt raises TypeError, then we pre-process and retry.
     """
     try:
-        return orjson.dumps(obj, default=envoxy_json_encode_default, option=_ORJSON_OPTS)
+        return orjson.dumps(
+            obj, default=envoxy_json_encode_default, option=_ORJSON_OPTS
+        )
     except TypeError as e:
         if "Integer exceeds 64-bit range" in str(e):
-            return orjson.dumps(_convert_large_integers(obj), default=envoxy_json_encode_default, option=_ORJSON_OPTS)
+            return orjson.dumps(
+                _convert_large_integers(obj),
+                default=envoxy_json_encode_default,
+                option=_ORJSON_OPTS,
+            )
         raise
 
 

--- a/tests/unit/test_asserts.py
+++ b/tests/unit/test_asserts.py
@@ -24,6 +24,8 @@ def test_assertz_mandatory_ok(test_payload):
 
     assert assertz_mandatory(test_payload, "password") is None
     assert assertz_mandatory(test_payload["application_ids"], 1) is None
+    # Empty string is a valid value — assertz_mandatory must not raise for it.
+    assert assertz_mandatory(test_payload, "username") is None
 
 
 def test_assertz_mandatory_nok(test_payload):
@@ -35,9 +37,6 @@ def test_assertz_mandatory_nok(test_payload):
     with pytest.raises(ValidationException) as e:
         assertz_mandatory(test_payload, "")
     assert str(e.value) == "Key must not be emtpy"
-
-    with pytest.raises(ValidationException) as e:
-        assertz_mandatory(test_payload, "username")
 
     with pytest.raises(ValidationException) as e:
         assertz_mandatory(test_payload["user"], "last_name")

--- a/vendors/pyproject.toml
+++ b/vendors/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "envoxyd"
-version = "0.5.22"
+version = "0.6.0"
 description = "Customized uWSGI server for Envoxy"
 requires-python = ">=3.12"
 authors = [


### PR DESCRIPTION
This pull request introduces first-class support for ClickHouse as a read-only analytics database in the Envoxy framework, alongside some minor formatting and dependency changes. The main updates include adding a ClickHouse client and dispatcher, updating configuration and dependency files, and ensuring consistent code formatting.

**ClickHouse integration:**

* Added `ClickHouseClient` and corresponding imports, as well as a `ClickHouseDispatcher` (`chsqlc`) static interface for executing read-only analytics queries against ClickHouse, mirroring the existing PostgreSQL dispatcher for easy swapping. (`src/envoxy/db/dispatcher.py`, `src/envoxy/__init__.py`, `src/envoxy/clickhouse/__init__.py`) [[1]](diffhunk://#diff-8a66f2edfdc0dec81c32cda8185b8543331dae5beb0718c45841ee738891ad14R152) [[2]](diffhunk://#diff-2de4eef7e935b95a9d592d496cb18f5fdbbfdd62149cdc3b9c2da78180d8f7eeR13) [[3]](diffhunk://#diff-2de4eef7e935b95a9d592d496cb18f5fdbbfdd62149cdc3b9c2da78180d8f7eeR39-R48) [[4]](diffhunk://#diff-2de4eef7e935b95a9d592d496cb18f5fdbbfdd62149cdc3b9c2da78180d8f7eeR123-R142) [[5]](diffhunk://#diff-2de4eef7e935b95a9d592d496cb18f5fdbbfdd62149cdc3b9c2da78180d8f7eeR186-R203) [[6]](diffhunk://#diff-2de4eef7e935b95a9d592d496cb18f5fdbbfdd62149cdc3b9c2da78180d8f7eeR402-R477) [[7]](diffhunk://#diff-a1732d811b2026f04257d241c51ead4a25dfb4708a33599b53950d091e8a9727R1-R2)
* Added initialization logic to read ClickHouse server configurations from `clickhouse_servers` in the application config, with error handling for missing configs. (`src/envoxy/db/dispatcher.py`)
* Exposed a `clickhouse` property and singleton connector for accessing the ClickHouse client. (`src/envoxy/db/dispatcher.py`) [[1]](diffhunk://#diff-2de4eef7e935b95a9d592d496cb18f5fdbbfdd62149cdc3b9c2da78180d8f7eeR39-R48) [[2]](diffhunk://#diff-2de4eef7e935b95a9d592d496cb18f5fdbbfdd62149cdc3b9c2da78180d8f7eeR186-R203)

**Dependency and configuration updates:**

* Added `clickhouse-connect>=1.0.1` to project dependencies and bumped the Envoxy version to `0.7.0` to reflect the new feature. (`pyproject.toml`) [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R46) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7)
* Bumped the version of the related `envoxyd` package to `0.6.0`. (`vendors/pyproject.toml`)

**Formatting and minor improvements:**

* Improved code formatting for logging and JSON encoding for better readability and consistency. (`src/envoxy/tools/alembic/alembic/env.py`, `src/envoxy/utils/encoders.py`) [[1]](diffhunk://#diff-bcafa5a27eb5f3837802ce881e8d18f014faf74e3c3b6741233413df9bb05ac5L293-R303) [[2]](diffhunk://#diff-bcafa5a27eb5f3837802ce881e8d18f014faf74e3c3b6741233413df9bb05ac5L309-R321) [[3]](diffhunk://#diff-f25696fc6fd9023826a29a1bc6cdea01b628a594ce21c78fbdb973969baa4fe4L75-R84)
* Updated ruff linting directives for stricter import order enforcement. (`src/envoxy/__init__.py`)

These changes lay the groundwork for robust, read-only analytics querying via ClickHouse, with a familiar interface for existing Envoxy users.