### PR TITLE
version bump

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "envoxy"
-version = "0.7.0"
+version = "0.7.1"
 description = "Envoxy Platform Framework"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/vendors/pyproject.toml
+++ b/vendors/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "envoxyd"
-version = "0.6.0"
+version = "0.6.1"
 description = "Customized uWSGI server for Envoxy"
 requires-python = ">=3.12"
 authors = [
@@ -20,7 +20,7 @@ classifiers = [
     "Development Status :: 4 - Beta",
 ]
 
-dependencies = ["envoxy>=0.6.20", "flask-cors==6.0.1", "isort==7.0.0"]
+dependencies = ["envoxy>=0.7.1", "flask-cors==6.0.1", "isort==7.0.0"]
 
 [project.urls]
 Homepage = "https://github.com/habitio/envoxy"


### PR DESCRIPTION
This pull request updates versioning and dependency requirements for both the main `envoxy` framework and its vendor package `envoxyd`. The most important changes are version bumps and ensuring that `envoxyd` depends on the latest `envoxy` release.

Version updates:

* Bumped the version of the main `envoxy` package from `0.7.0` to `0.7.1` in `pyproject.toml`.
* Bumped the version of the `envoxyd` vendor package from `0.6.0` to `0.6.1` in `vendors/pyproject.toml`.

Dependency updates:

* Updated the `envoxyd` dependency on `envoxy` to require at least version `0.7.1` (was `>=0.6.20`) in `vendors/pyproject.toml`.